### PR TITLE
Simplify server and don't send content length

### DIFF
--- a/serve
+++ b/serve
@@ -1,15 +1,11 @@
 #!/bin/bash
-RUNNING=true
-PORT=${PORT:-80}
-ECHO=${ECHO:-"echo"}
-LENGTH=$(echo "$ECHO" | wc -c)
+PORT=${PORT:-8080}
+ECHO=${ECHO:-echo}
 
-trap quit INT
+RESPONSE="HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n${ECHO}\r\n"
 
-function quit() {
-  echo "Quiting..."
-  RUNNING=false
-}
-
-echo "Listening on port ${PORT}..."
-while ${RUNNING} ; do nc -l -p ${PORT} -c "printf 'HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: ${LENGTH}\nConnection: close\n\n${ECHO}\n'"; done
+echo "Listening on $PORT"
+while true; do
+  { echo -en "$RESPONSE" | nc -l "$PORT" &>/dev/null; } || break
+done
+echo "Quiting..."

--- a/serve
+++ b/serve
@@ -1,8 +1,9 @@
 #!/bin/bash
 PORT=${PORT:-8080}
 ECHO=${ECHO:-echo}
+LENGTH=$(echo "$ECHO" | wc -c)
 
-RESPONSE="HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n${ECHO}\r\n"
+RESPONSE="HTTP/1.1 200 OK\r\nContent-Length: $LENGTH\r\nConnection: close\r\n\r\n$ECHO"
 
 echo "Listening on $PORT"
 while true; do


### PR DESCRIPTION
The pipeline keeps failing on the `curl` stage with an error indicating not all content was sent.

This change simplifies the control loop and removes the `Content-*` headers. The [spec](https://tools.ietf.org/html/rfc2616#section-4.4) allows us to not send the `Content-Length` header and clients will determine the length after the connection is closed - which netcat will do.

Also uses `echo -e` for handle control characters instead of netcat's `printf` to make it a bit more readable